### PR TITLE
Feature: changes to time series plots to start axis from origin

### DIFF
--- a/R/create_line.R
+++ b/R/create_line.R
@@ -127,7 +127,9 @@ create_line <- function(data,
                           camel_clean(hrvar))) +
     xlab("Date") +
     ylab("Weekly hours") +
-    labs(caption = extract_date_range(data, return = "text"))
+    labs(caption = extract_date_range(data, return = "text")) +
+    ylim(0, NA) # Set origin to zero
+
 
   if(return == "table"){
 

--- a/R/identify_holidayweeks.R
+++ b/R/identify_holidayweeks.R
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-#' @title Identify Holiday Weeks
+#' @title Identify Holiday Weeks based on outliers
 #'
 #' @description
 #' This function scans a standard query output for weeks where collaboration hours is far outside the mean.
@@ -20,7 +20,7 @@
 #'   - When 'data' is passed, a dataset with outlier weeks flagged in a new column is returned as a dataframe.
 #'   - When 'data_cleaned' is passed, a dataset with outlier weeks removed is returned as a dataframe.
 #'   - when 'data_dirty' is passed, a dataset with only outlier weeks is returned as a dataframe.
-#'   - when 'plot' is passed, a pot with holiday weeks highlighted is returned as a dataframe.
+#'   - when 'plot' is passed, a plot with holiday weeks highlighted is returned as a dataframe.
 #'
 #' @import dplyr
 #' @import ggplot2
@@ -86,27 +86,47 @@ identify_holidayweeks <- function(data, sd = 1, return = "message"){
     geom_line(colour = "grey40") +
     theme_wpa_basic() +
     geom_rect(data = myTable_plot_shade,
-              aes(xmin = min, xmax = max, ymin = ymin, ymax = ymax),
-              color="transparent", fill="steelblue", alpha=0.3) +
+              aes(xmin = min,
+                  xmax = max,
+                  ymin = ymin,
+                  ymax = ymax),
+              color = "transparent",
+              fill = "steelblue",
+              alpha = 0.3) +
     labs(title = "Holiday Weeks",
          subtitle = "Showing average collaboration hours over time")+
     ylab("Collaboration Hours") +
-    xlab("Date")
+    xlab("Date") +
+    ylim(0, NA) # Set origin to zero
 
   if(return == "text"){
+
     return(Message)
+
   } else if(return == "message"){
+
     message(Message)
-  }else if(return %in% c("data_clean", "data_cleaned")){
+
+  } else if(return %in% c("data_clean", "data_cleaned")){
+
     return(data %>% filter(!(Date %in% Outliers)) %>% data.frame())
+
   } else if(return == "data_dirty"){
+
     return(data %>% filter((Date %in% Outliers)) %>% data.frame())
+
   } else if(return == "data"){
+
     return(data %>% mutate(holidayweek = (Date %in% Outliers)) %>% data.frame())
+
   } else if(return == "plot"){
+
     return(plot)
+
   } else {
-    stop("Error: please check inputs for `return`")
+
+    stop("Invalid input for `return`.")
+
   }
 }
 

--- a/man/identify_holidayweeks.Rd
+++ b/man/identify_holidayweeks.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/identify_holidayweeks.R
 \name{identify_holidayweeks}
 \alias{identify_holidayweeks}
-\title{Identify Holiday Weeks}
+\title{Identify Holiday Weeks based on outliers}
 \usage{
 identify_holidayweeks(data, sd = 1, return = "message")
 }
@@ -18,7 +18,7 @@ Valid options are:
 \item When 'data' is passed, a dataset with outlier weeks flagged in a new column is returned as a dataframe.
 \item When 'data_cleaned' is passed, a dataset with outlier weeks removed is returned as a dataframe.
 \item when 'data_dirty' is passed, a dataset with only outlier weeks is returned as a dataframe.
-\item when 'plot' is passed, a pot with holiday weeks highlighted is returned as a dataframe.
+\item when 'plot' is passed, a plot with holiday weeks highlighted is returned as a dataframe.
 }}
 }
 \description{


### PR DESCRIPTION
# Summary
This branch changes the default behaviour of some time series plots in the package to start their vertical axes from the origin. This is a simple fix by adding `+ ylim(0, NA)` to the end of the ggplot chains. 

# Changes
Updated functions in this PR are:
1. `identify_holidayweeks()`
1. `create_line()` (effect ripples through to wrapper functions)

# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #42.