### PR TITLE
Bug Fix: `flag_outlooktime()` throwing up error on Standard Person Queries

### DIFF
--- a/R/flag_outlooktime.R
+++ b/R/flag_outlooktime.R
@@ -19,7 +19,15 @@
 #' @family Data Validation
 #'
 #' @examples
+#' # Demo with `dv_data`
 #' flag_outlooktime(dv_data)
+#'
+#' # Example where Outlook Start and End times are imputed
+#' spq_df <- sq_data
+#' spq_df$WorkingStartTimeSetInOutlook <- "6:30"
+#' spq_df$WorkingEndTimeSetInOutlook <- "23:30"
+#' flag_outlooktime(spq_df, threshold = c(5, 13))
+#'
 #' @export
 flag_outlooktime <- function(data, threshold = c(4, 15), return = "message"){
 

--- a/R/flag_outlooktime.R
+++ b/R/flag_outlooktime.R
@@ -37,9 +37,39 @@ flag_outlooktime <- function(data, threshold = c(4, 15), return = "message"){
   #
   # pad_times <- Vectorize(pad_times)
 
-  if(any(nchar(data$WorkingStartTimeSetInOutlook) != 5 | nchar(data$WorkingEndTimeSetInOutlook) != 5)){
+  ## Clean `WorkingStartTimeSetInOutlook`
+
+  if(any(grepl(pattern = "\\d{1}:\\d{1,2}", x = data$WorkingStartTimeSetInOutlook))){
+
+    # Pad two zeros and keep last five characters
+    data$WorkingStartTimeSetInOutlook <-
+      paste0("00", data$WorkingStartTimeSetInOutlook) %>%
+      substr(start = nchar(.) - 4, stop = nchar(.))
+
+  }
+
+  ## Clean `WorkingEndTimeSetInOutlook`
+
+  if(any(grepl(pattern = "\\d{1}:\\d{1,2}", x = data$WorkingEndTimeSetInOutlook))){
+
+    # Pad two zeros and keep last five characters
+    data$WorkingEndTimeSetInOutlook <-
+      paste0("00", data$WorkingEndTimeSetInOutlook) %>%
+      substr(start = nchar(.) - 4, stop = nchar(.))
+
+
+  }
+
+  if(
+      any(
+        !grepl(pattern = "\\d{1,2}:\\d{1,2}", x = data$WorkingStartTimeSetInOutlook) |
+        !grepl(pattern = "\\d{1,2}:\\d{1,2}", x = data$WorkingEndTimeSetInOutlook)
+      )
+    ){
+
     stop("Please check data format for `WorkingStartTimeSetInOutlook` or `WorkingEndTimeSetInOutlook.\n
          These variables must be character vectors, and have the format `%H:%M`, such as `07:30` or `23:00`.")
+
   }
 
   clean_times <- function(x){

--- a/man/flag_outlooktime.Rd
+++ b/man/flag_outlooktime.Rd
@@ -20,7 +20,15 @@ This function flags unusual outlook calendar settings for
 start and end time of work day.
 }
 \examples{
+# Demo with `dv_data`
 flag_outlooktime(dv_data)
+
+# Example where Outlook Start and End times are imputed
+spq_df <- sq_data
+spq_df$WorkingStartTimeSetInOutlook <- "6:30"
+spq_df$WorkingEndTimeSetInOutlook <- "23:30"
+flag_outlooktime(spq_df, threshold = c(5, 13))
+
 }
 \seealso{
 Other Data Validation: 


### PR DESCRIPTION
# Summary
This branch tackles the problem of `flag_outlooktime()` throwing up errors when a Standard Person Query is passed through. 
This is caused by outlook start and end times which are passed as `"7:30"` instead of `"07:30"`. This is overly strict and causes issues when using the `validation_report()`, which depends on `flag_outlooktime()`.

The solution is to add a formatter within the function which accepts both formats:
```R
## Clean `WorkingStartTimeSetInOutlook`
  if(any(grepl(pattern = "\\d{1}:\\d{1,2}", x = data$WorkingStartTimeSetInOutlook))){

    # Pad two zeros and keep last five characters
    data$WorkingStartTimeSetInOutlook <-
      paste0("00", data$WorkingStartTimeSetInOutlook) %>%
      substr(start = nchar(.) - 4, stop = nchar(.))

  }

  ## Clean `WorkingEndTimeSetInOutlook`

  if(any(grepl(pattern = "\\d{1}:\\d{1,2}", x = data$WorkingEndTimeSetInOutlook))){

    # Pad two zeros and keep last five characters
    data$WorkingEndTimeSetInOutlook <-
      paste0("00", data$WorkingEndTimeSetInOutlook) %>%
      substr(start = nchar(.) - 4, stop = nchar(.))


  }

## Only allow if the final format is "hh:mm"
  if(
      any(
        !grepl(pattern = "\\d{1,2}:\\d{1,2}", x = data$WorkingStartTimeSetInOutlook) |
        !grepl(pattern = "\\d{1,2}:\\d{1,2}", x = data$WorkingEndTimeSetInOutlook)
      )
    ){
```


# Changes
The changes made in this PR are:
1. Added some conditionals within `flag_outlooktime()` so that `h:mm` will be formatted internally within the function to `hh:mm` so that it will not throw up an error.
1. Added an example in the function documentation which tests for both scenarios. If a future code change affects this piece, the error can be identified through the test.


# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.
