### PR TITLE
Bug Fix: reading double-byte characters in `import_wpa()`

### DIFF
--- a/R/import_wpa.R
+++ b/R/import_wpa.R
@@ -14,20 +14,30 @@
 #' and by default `stringsAsFactors` is set to FALSE.
 #' A data frame is returned by the function (not a `data.table`).
 #'
-#' @param x String containing the path to the Workplace Analytics query to be imported.
-#' The input file must be a CSV file, and the file extension must be explicitly entered,
-#' e.g. "/files/standard query.csv"
-#' @param standardise logical. If TRUE, `import_wpa()` runs `standardise_pq()` to make a Collaboration
-#' Assessment query's columns name standard and consistent with a Standard Person Query. Note that this
-#' will have no effect if the query being imported is not a Ways of Working Assessment query. Defaults
-#' as FALSE.
+#' @param x String containing the path to the Workplace Analytics query to be
+#'   imported. The input file must be a CSV file, and the file extension must be
+#'   explicitly entered, e.g. `"/files/standard query.csv"`
+#' @param standardise logical. If TRUE, `import_wpa()` runs `standardise_pq()`
+#'   to make a Collaboration Assessment query's columns name standard and
+#'   consistent with a Standard Person Query. Note that this will have no effect
+#'   if the query being imported is not a Ways of Working Assessment query.
+#'   Defaults as FALSE.
+#' @param encoding String to specify encoding to be used within
+#'   `data.table::fread()`. See `data.table::fread()` documentation for more
+#'   information. Defaults to `'UTF-8'`.
 #'
 #' @return A `tibble` is returned.
 #'
 #' @export
-import_wpa <- function(x, standardise = FALSE){
+import_wpa <- function(x,
+                       standardise = FALSE,
+                       encoding = 'UTF-8'){
 
-  return_data <- data.table::fread(x, stringsAsFactors = FALSE) %>% as.data.frame()
+  return_data <-
+    data.table::fread(x,
+                      stringsAsFactors = FALSE,
+                      encoding = encoding) %>%
+    as.data.frame()
 
   # Columns which are Dates
   dateCols <- sapply(return_data, function(x) all(is_date_format(x)))

--- a/man/import_wpa.Rd
+++ b/man/import_wpa.Rd
@@ -4,17 +4,22 @@
 \alias{import_wpa}
 \title{Import a Workplace Analytics Query}
 \usage{
-import_wpa(x, standardise = FALSE)
+import_wpa(x, standardise = FALSE, encoding = "UTF-8")
 }
 \arguments{
-\item{x}{String containing the path to the Workplace Analytics query to be imported.
-The input file must be a CSV file, and the file extension must be explicitly entered,
-e.g. "/files/standard query.csv"}
+\item{x}{String containing the path to the Workplace Analytics query to be
+imported. The input file must be a CSV file, and the file extension must be
+explicitly entered, e.g. \code{"/files/standard query.csv"}}
 
-\item{standardise}{logical. If TRUE, \code{import_wpa()} runs \code{standardise_pq()} to make a Collaboration
-Assessment query's columns name standard and consistent with a Standard Person Query. Note that this
-will have no effect if the query being imported is not a Ways of Working Assessment query. Defaults
-as FALSE.}
+\item{standardise}{logical. If TRUE, \code{import_wpa()} runs \code{standardise_pq()}
+to make a Collaboration Assessment query's columns name standard and
+consistent with a Standard Person Query. Note that this will have no effect
+if the query being imported is not a Ways of Working Assessment query.
+Defaults as FALSE.}
+
+\item{encoding}{String to specify encoding to be used within
+\code{data.table::fread()}. See \code{data.table::fread()} documentation for more
+information. Defaults to \code{'UTF-8'}.}
 }
 \value{
 A \code{tibble} is returned.


### PR DESCRIPTION
# Summary
This branch added the ability to specify encoding for `import_wpa()`. The new default used is 'UTF-8'.

# Changes
The changes made in this PR are:
1. Added a new argument `encoding` in `import_wpa()`. This feature feeds onto the underlying `data.table::fread()` function. The default is changed to 'UTF-8' to work with double-byte characters.

This has been tested with some dummy data and works:

![image](https://user-images.githubusercontent.com/17925865/108404756-22967780-7218-11eb-974a-74f4f40e1157.png)


# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #73.

