### PR TITLE
Bug fix: no return for `collab_line()`

### DIFF
--- a/R/collaboration_line.R
+++ b/R/collaboration_line.R
@@ -30,11 +30,11 @@
 
 collaboration_line <- function(data,
                                 hrvar = "Organization",
-                                mingroup=5,
+                                mingroup = 5,
                                 return = "plot"){
 
   ## Inherit arguments
-  output <- create_line(data = data,
+  create_line(data = data,
               metric = "Collaboration_hours",
               hrvar = hrvar,
               mingroup = mingroup,


### PR DESCRIPTION
# Summary
This branch fixes the error mentioned in #71 where `collab_line()` returns no output.

# Changes
The changes made in this PR are:
1. Fixed error within `collab_line()`. This does not affect other `*_line()` functions.

# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #71.
