### PR TITLE
Bugfix: relax variable name checks to `collab_area()` 

### DIFF
--- a/R/collaboration_area.R
+++ b/R/collaboration_area.R
@@ -50,34 +50,49 @@ collaboration_area <- function(data,
                                mingroup=5,
                                return = "plot"){
 
+  ## Date cleaning
   data$Date <- as.Date(data$Date, format = "%m/%d/%Y")
 
-  if("Instant_message_hours" %in% names(data)){
+  ## Lower case version of column names
+  lnames <- tolower(names(data))
 
-    data <- rename(data, Instant_Message_hours = "Instant_message_hours")
+  if("instant_message_hours" %in% lnames){
+
+    names(data) <-
+      gsub(pattern = "instant_message_hours",
+           replacement = "Instant_Message_hours",
+           x = names(data),
+           ignore.case = TRUE) # Case-insensitive
 
   }
 
-  if("Unscheduled_call_hours" %in% names(data)){
+  if("unscheduled_call_hours" %in% lnames){
+
+    names(data) <-
+      gsub(pattern = "unscheduled_call_hours",
+           replacement = "Unscheduled_Call_hours",
+           x = names(data),
+           ignore.case = TRUE) # Case-insensitive
 
     data <- rename(data, Unscheduled_Call_hours = "Unscheduled_call_hours")
 
   }
 
-  if("Unscheduled_Call_hours" %in% names(data)){
+  ## Exclude metrics if not available as a metric
 
-    main_vars <- c("Meeting_hours",
-                   "Email_hours",
-                   "Instant_Message_hours",
-                   "Unscheduled_Call_hours")
+  check_chr <- c("^Meeting_hours$",
+                 "^Email_hours$",
+                 "^Instant_Message_hours$",
+                 "^Unscheduled_Call_hours$")
 
-  } else {
+  main_vars <-
+    names(data)[
+    grepl(pattern = paste(check_chr, collapse = "|"),
+          x = lnames,
+          ignore.case = TRUE)
+  ]
 
-    main_vars <- c("Meeting_hours",
-                   "Email_hours",
-                   "Instant_Message_hours")
-
-  }
+  ## Analysis table
 
   myTable <-
     data %>%

--- a/R/collaboration_area.R
+++ b/R/collaboration_area.R
@@ -17,8 +17,9 @@
 #' @param data A Standard Person Query dataset in the form of a data frame.
 #' A Ways of Working assessment dataset may also be provided, in which
 #' Unscheduled call hours would be included in the output.
-#' @param hrvar HR Variable by which to split metrics, defaults to
-#'   "Organization" but accepts any character vector, e.g. "LevelDesignation"
+#' @param hrvar HR Variable by which to split metrics, defaults to `NULL`, but
+#'   accepts any character vector, e.g. "LevelDesignation". If `NULL` is passed,
+#'   the organizational attribute is automatically populated as "Total".
 #' @param mingroup Numeric value setting the privacy threshold / minimum group
 #'   size. Defaults to 5.
 #' @param return String specifying what to return. This must be one of the
@@ -36,7 +37,14 @@
 #' @family Collaboration
 #'
 #' @examples
+#' # Return plot with total (default)
 #' collaboration_area(sq_data)
+#'
+#' # Return plot with hrvar split
+#' collaboration_area(sq_data, hrvar = "Organization")
+#'
+#' # Return summary table
+#' collaboration_area(sq_data, return = "table")
 #'
 #' @return
 #' A different output is returned depending on the value passed to the `return` argument:
@@ -46,9 +54,15 @@
 #' @export
 
 collaboration_area <- function(data,
-                               hrvar = "Organization",
+                               hrvar = NULL,
                                mingroup=5,
                                return = "plot"){
+
+  ## Handling NULL values passed to hrvar
+  if(is.null(hrvar)){
+    data <- totals_col(data)
+    hrvar <- "Total"
+  }
 
   ## Date cleaning
   data$Date <- as.Date(data$Date, format = "%m/%d/%Y")
@@ -73,8 +87,6 @@ collaboration_area <- function(data,
            replacement = "Unscheduled_Call_hours",
            x = names(data),
            ignore.case = TRUE) # Case-insensitive
-
-    data <- rename(data, Unscheduled_Call_hours = "Unscheduled_call_hours")
 
   }
 

--- a/man/collaboration_area.Rd
+++ b/man/collaboration_area.Rd
@@ -5,17 +5,18 @@
 \alias{collab_area}
 \title{Collaboration - Stacked Area Plot}
 \usage{
-collaboration_area(data, hrvar = "Organization", mingroup = 5, return = "plot")
+collaboration_area(data, hrvar = NULL, mingroup = 5, return = "plot")
 
-collab_area(data, hrvar = "Organization", mingroup = 5, return = "plot")
+collab_area(data, hrvar = NULL, mingroup = 5, return = "plot")
 }
 \arguments{
 \item{data}{A Standard Person Query dataset in the form of a data frame.
 A Ways of Working assessment dataset may also be provided, in which
 Unscheduled call hours would be included in the output.}
 
-\item{hrvar}{HR Variable by which to split metrics, defaults to
-"Organization" but accepts any character vector, e.g. "LevelDesignation"}
+\item{hrvar}{HR Variable by which to split metrics, defaults to \code{NULL}, but
+accepts any character vector, e.g. "LevelDesignation". If \code{NULL} is passed,
+the organizational attribute is automatically populated as "Total".}
 
 \item{mingroup}{Numeric value setting the privacy threshold / minimum group
 size. Defaults to 5.}
@@ -46,7 +47,14 @@ Uses the metrics \code{Meeting_hours}, \code{Email_hours}, \code{Unscheduled_Cal
 and \code{Instant_Message_hours}.
 }
 \examples{
+# Return plot with total (default)
 collaboration_area(sq_data)
+
+# Return plot with hrvar split
+collaboration_area(sq_data, hrvar = "Organization")
+
+# Return summary table
+collaboration_area(sq_data, return = "table")
 
 }
 \seealso{


### PR DESCRIPTION
# Summary
This branch fixes the problem where the variable name checks in `collaboration_area()` is overly strict, and resolves it by making it case-sensitive. This branch is a direct fix of issue #72 as raised by @juliajuju93.

![image](https://user-images.githubusercontent.com/17925865/108754136-7917f480-753d-11eb-8f78-6f21a8dceb5c.png)

# Changes
The changes made in this PR are:
1. Makes the variable name checks within `collaboration_area()` **case-insensitive**.
1. Makes it a default behaviour to return the output with `hrvar` set to `NULL`, and adds the ability for it to run it as a total view. This is an extension of #22 raised by @AinizeCidoncha.
1. Expanded examples in the documentation of this function.  


# Checks
- [ ] All R CMD checks pass 
- [ ] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #72.

