### PR TITLE
Feature: improvements to `network_g2g()`

### DIFF
--- a/R/network_g2g.R
+++ b/R/network_g2g.R
@@ -19,11 +19,22 @@
 #'   `Collaboration_hours`.
 #' @param exc_threshold Exclusion threshold to apply.
 #' @param subtitle String to override default plot subtitle.
-#' @param return Character vector specifying what to return, defaults to "plot".
-#' Valid inputs include:
-#'   - "plot": return a network plot.
-#'   - "table": return a raw data table used to plot the network.
-#'   - "network": return an **igraph** object
+#' @param return String specifying what to return. This must be one of the
+#'   following strings:
+#'   - `"plot"`
+#'   - `"table"`
+#'   - `"network"`
+#'   - `"data"`
+#'
+#' See `Value` for more information.
+#'
+#' @return
+#' A different output is returned depending on the value passed to the `return`
+#' argument:
+#'   - `"plot"`: ggplot object. A group-to-group network plot.
+#'   - `"table"`: data frame. A summary table for the metric.
+#'   - `"network`: igraph object used for creating the network plot.
+#'   - `"data`: data frame. An interactive matrix of the network.
 #'
 #' @import ggplot2
 #' @import dplyr
@@ -38,6 +49,12 @@
 #'               collaborator = "Collaborators_Organization",
 #'               metric = "Meeting_hours",
 #'               exc_threshold = 0.05)
+#'
+#' # Return an interaction matrix
+#' # Minimum arguments specified
+#' g2g_data %>%
+#'   network_g2g(return = "data")
+#'
 #'
 #' @export
 network_g2g <- function(data,
@@ -106,7 +123,10 @@ network_g2g <- function(data,
 
   if(return == "table"){
 
-    plot_data
+    ## Return a 'tidy' matrix
+    plot_data %>%
+      tidyr::pivot_wider(names_from = CollaboratorOrg,
+                         values_from = metric_prop)
 
   } else if(return %in% c("plot", "network")){
 

--- a/R/network_g2g.R
+++ b/R/network_g2g.R
@@ -24,6 +24,7 @@
 #'   - `"plot"`
 #'   - `"table"`
 #'   - `"network"`
+#'   - `"data"`
 #'
 #' See `Value` for more information.
 #'
@@ -33,6 +34,7 @@
 #'   - `"plot"`: ggplot object. A group-to-group network plot.
 #'   - `"table"`: data frame. An interactive matrix of the network.
 #'   - `"network`: igraph object used for creating the network plot.
+#'   - `"data"`: data frame. A long table of the underlying data.
 #'
 #' @import ggplot2
 #' @import dplyr
@@ -51,7 +53,7 @@
 #' # Return an interaction matrix
 #' # Minimum arguments specified
 #' g2g_data %>%
-#'   network_g2g(return = "data")
+#'   network_g2g(return = "table")
 #'
 #'
 #' @export
@@ -125,6 +127,11 @@ network_g2g <- function(data,
     plot_data %>%
       tidyr::pivot_wider(names_from = CollaboratorOrg,
                          values_from = metric_prop)
+
+  } else if(return == "data"){
+
+    ## Return long table
+    plot_data
 
   } else if(return %in% c("plot", "network")){
 

--- a/R/network_g2g.R
+++ b/R/network_g2g.R
@@ -76,8 +76,18 @@ network_g2g <- function(data,
 
   }
 
+  ## Warn if 'Collaborators Within Group' is not present in data
+  if(! "Collaborators Within Group" %in% unique(data[[collaborator]])){
+
+    warning(
+      "`Collaborators Within Group` is not found in the collaborator variable.
+      The analysis may be excluding in-group collaboration."
+      )
+
+  }
 
 
+  ## Run plot_data
   plot_data <-
     data %>%
     rename(TimeInvestorOrg = time_investor,

--- a/R/network_g2g.R
+++ b/R/network_g2g.R
@@ -24,7 +24,6 @@
 #'   - `"plot"`
 #'   - `"table"`
 #'   - `"network"`
-#'   - `"data"`
 #'
 #' See `Value` for more information.
 #'
@@ -32,9 +31,8 @@
 #' A different output is returned depending on the value passed to the `return`
 #' argument:
 #'   - `"plot"`: ggplot object. A group-to-group network plot.
-#'   - `"table"`: data frame. A summary table for the metric.
+#'   - `"table"`: data frame. An interactive matrix of the network.
 #'   - `"network`: igraph object used for creating the network plot.
-#'   - `"data`: data frame. An interactive matrix of the network.
 #'
 #' @import ggplot2
 #' @import dplyr

--- a/man/network_g2g.Rd
+++ b/man/network_g2g.Rd
@@ -47,6 +47,7 @@ following strings:
 \item \code{"plot"}
 \item \code{"table"}
 \item \code{"network"}
+\item \code{"data"}
 }
 
 See \code{Value} for more information.}
@@ -58,6 +59,7 @@ argument:
 \item \code{"plot"}: ggplot object. A group-to-group network plot.
 \item \code{"table"}: data frame. An interactive matrix of the network.
 \item \verb{"network}: igraph object used for creating the network plot.
+\item \code{"data"}: data frame. A long table of the underlying data.
 }
 }
 \description{
@@ -79,7 +81,7 @@ g2g_data \%>\%
 # Return an interaction matrix
 # Minimum arguments specified
 g2g_data \%>\%
-  network_g2g(return = "data")
+  network_g2g(return = "table")
 
 
 }

--- a/man/network_g2g.Rd
+++ b/man/network_g2g.Rd
@@ -47,7 +47,6 @@ following strings:
 \item \code{"plot"}
 \item \code{"table"}
 \item \code{"network"}
-\item \code{"data"}
 }
 
 See \code{Value} for more information.}
@@ -57,9 +56,8 @@ A different output is returned depending on the value passed to the \code{return
 argument:
 \itemize{
 \item \code{"plot"}: ggplot object. A group-to-group network plot.
-\item \code{"table"}: data frame. A summary table for the metric.
+\item \code{"table"}: data frame. An interactive matrix of the network.
 \item \verb{"network}: igraph object used for creating the network plot.
-\item \verb{"data}: data frame. An interactive matrix of the network.
 }
 }
 \description{

--- a/man/network_g2g.Rd
+++ b/man/network_g2g.Rd
@@ -41,13 +41,26 @@ column.}
 
 \item{subtitle}{String to override default plot subtitle.}
 
-\item{return}{Character vector specifying what to return, defaults to "plot".
-Valid inputs include:
+\item{return}{String specifying what to return. This must be one of the
+following strings:
 \itemize{
-\item "plot": return a network plot.
-\item "table": return a raw data table used to plot the network.
-\item "network": return an \strong{igraph} object
-}}
+\item \code{"plot"}
+\item \code{"table"}
+\item \code{"network"}
+\item \code{"data"}
+}
+
+See \code{Value} for more information.}
+}
+\value{
+A different output is returned depending on the value passed to the \code{return}
+argument:
+\itemize{
+\item \code{"plot"}: ggplot object. A group-to-group network plot.
+\item \code{"table"}: data frame. A summary table for the metric.
+\item \verb{"network}: igraph object used for creating the network plot.
+\item \verb{"data}: data frame. An interactive matrix of the network.
+}
 }
 \description{
 Pass a data frame containing a group-to-group query and return a network
@@ -64,5 +77,11 @@ g2g_data \%>\%
               collaborator = "Collaborators_Organization",
               metric = "Meeting_hours",
               exc_threshold = 0.05)
+
+# Return an interaction matrix
+# Minimum arguments specified
+g2g_data \%>\%
+  network_g2g(return = "data")
+
 
 }


### PR DESCRIPTION
# Summary
This branch makes some improvements to `network_g2g()`, including adding the ability to return an interactive matrix (#82) and providing a warning if `'Collaborators Within Group'` is missing from the values of the Collaborators column (#70).

# Changes
The changes made in this PR are:
1. Issue a warning signal if `Collaborators Within Group` is missing from the data.
1. When `"data"` is  passed to `return`, a long table of the underlying data is returned. When `"table"` is passed to `return`, an interaction matrix (as a data frame) is returned.


# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #70 and #82.
