### PR TITLE
Feature: return typed data for `mgrrel_matrix()`

### DIFF
--- a/R/mgrrel_matrix.R
+++ b/R/mgrrel_matrix.R
@@ -12,13 +12,36 @@
 #' @param data Standard Person Query data to pass through. Accepts a data frame.
 #' @param hrvar HR Variable by which to split metrics. Accepts a character vector,
 #' e.g. "Organization". Defaults to NULL.
-#' @param return A character vector specifying whether to return a matrix plot or a table.
-#' Defaults to the 2 by 2 matrix. Valid values are "plot", "table", and "chartdata".
+#'
+#' @param return String specifying what to return. This must be one of the
+#'   following strings:
+#'   - `"plot"`
+#'   - `"table"`
+#'   - `"data"`
+#'
+#' See `Value` for more information.
+#'
 #' @param plot_colors
 #' Pass a character vector of length 4 containing HEX codes to specify colors to use in plotting.
 #' @param threshold
 #' Specify a numeric value to determine threshold (in minutes) for 1:1 manager hours.
 #' Defaults to 15.
+#'
+#' @return
+#' A different output is returned depending on the value passed to the `return`
+#' argument:
+#'   - `"plot"`: ggplot object. When `NULL` is passed to `hrvar`, a two-by-two
+#'   grid where the size of the grid represents total percentage of employees is
+#'   returned. Otherwise, a horizontal stacked bar plot is returned.
+#'   - `"table"`: data frame. A summary table is returned.
+#'   - `"data"`: data frame. A long table grouped at the `PersonId` level with
+#'   the following columns:
+#'     - `PersonId`
+#'     - HR variable supplied to `hrvar`
+#'     - `CoattendanceRate`
+#'     - `Meeting_hours_with_manager_1_on_1`
+#'     - `mgr1on1`
+#'     - `Type`
 #'
 #' @import dplyr
 #' @import reshape2
@@ -29,7 +52,27 @@
 #' @family Meeting Culture
 #'
 #' @examples
+#' # Return matrix
 #' mgrrel_matrix(sq_data)
+#'
+#' # Return stacked bar plot
+#' mgrrel_matrix(sq_data, hrvar = "Organization")
+#'
+#' ## Visualize coaching style types
+#' # Ensure dplyr is loaded
+#' library(dplyr)
+#'
+#' # Extract PersonId and Coaching Type
+#' match_df <-
+#'   sq_data %>%
+#'   mgrrel_matrix(return = "data") %>%
+#'   select(PersonId, Type)
+#'
+#' # Join and visualize baseline
+#' sq_data %>%
+#'   left_join(match_df, by = "PersonId") %>%
+#'   keymetrics_scan(hrvar = "Type",
+#'                   return = "plot")
 #'
 #' @export
 mgrrel_matrix <- function(data,
@@ -217,6 +260,22 @@ mgrrel_matrix <- function(data,
     chart %>%
       as_tibble() %>%
       return()
+
+  } else if(return == "data"){
+
+
+    data2 %>%
+      mutate(Type =
+               case_when(mgr1on1 == thres_low_chr & coattendande == "<50%" ~ "Under-coached",
+                         mgr1on1 == thres_low_chr & coattendande == ">50%" ~ "Co-attending",
+                         mgr1on1 == thres_top_chr & coattendande == ">50%" ~ "Highly managed",
+                         TRUE ~ "Coaching")) %>%
+      select(PersonId,
+             !!sym(hrvar),
+             CoattendanceRate = "coattendman_rate",
+             Meeting_hours_with_manager_1_on_1,
+             mgr1on1,
+             Type)
 
   } else {
 

--- a/man/mgrrel_matrix.Rd
+++ b/man/mgrrel_matrix.Rd
@@ -18,20 +18,67 @@ mgrrel_matrix(
 \item{hrvar}{HR Variable by which to split metrics. Accepts a character vector,
 e.g. "Organization". Defaults to NULL.}
 
-\item{return}{A character vector specifying whether to return a matrix plot or a table.
-Defaults to the 2 by 2 matrix. Valid values are "plot", "table", and "chartdata".}
+\item{return}{String specifying what to return. This must be one of the
+following strings:
+\itemize{
+\item \code{"plot"}
+\item \code{"table"}
+\item \code{"data"}
+}
+
+See \code{Value} for more information.}
 
 \item{plot_colors}{Pass a character vector of length 4 containing HEX codes to specify colors to use in plotting.}
 
 \item{threshold}{Specify a numeric value to determine threshold (in minutes) for 1:1 manager hours.
 Defaults to 15.}
 }
+\value{
+A different output is returned depending on the value passed to the \code{return}
+argument:
+\itemize{
+\item \code{"plot"}: ggplot object. When \code{NULL} is passed to \code{hrvar}, a two-by-two
+grid where the size of the grid represents total percentage of employees is
+returned. Otherwise, a horizontal stacked bar plot is returned.
+\item \code{"table"}: data frame. A summary table is returned.
+\item \code{"data"}: data frame. A long table grouped at the \code{PersonId} level with
+the following columns:
+\itemize{
+\item \code{PersonId}
+\item HR variable supplied to \code{hrvar}
+\item \code{CoattendanceRate}
+\item \code{Meeting_hours_with_manager_1_on_1}
+\item \code{mgr1on1}
+\item \code{Type}
+}
+}
+}
 \description{
 Generate the Manager-Relationship 2x2 matrix, returning a ggplot object by default.
 Additional options available to return a "wide" or "long" summary table.
 }
 \examples{
+# Return matrix
 mgrrel_matrix(sq_data)
+
+# Return stacked bar plot
+mgrrel_matrix(sq_data, hrvar = "Organization")
+
+## Visualize coaching style types
+# Ensure dplyr is loaded
+library(dplyr)
+
+# Extract PersonId and Coaching Type
+match_df <-
+  sq_data \%>\%
+  mgrrel_matrix(return = "data") \%>\%
+  select(PersonId, Type)
+
+# Join and visualize baseline
+sq_data \%>\%
+  left_join(match_df, by = "PersonId") \%>\%
+  keymetrics_scan(hrvar = "Type",
+                  return = "plot")
 
 }
 \seealso{


### PR DESCRIPTION
# Summary
This branch makes an improvement to `mgrrel_matrix()` as per #83, adding an ability to return a raw data view with `mgrrel_matrix()` where the coaching types can be joined back to a Standard Person Query for further analysis. Documentation is also improved.

# Changes
The changes made in this PR are:
1. When `"data"` is passed to `return`, a person-level data frame is returned. This can then be merged with any Person Query with the `PersonId` for further analysis.
1. Clean and refine documentation on argument types.
1. Additional examples added to the documentation. 


# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #83.

# Example
Coaching personas baseline visualized with `keymetrics_scan()`.
![image](https://user-images.githubusercontent.com/17925865/108866905-8f30be00-75ec-11eb-9b8a-dc5ed3e9b51d.png)
