### PR TITLE
Bugfix: update `one2one_freq()`

### DIFF
--- a/R/one2one_freq.R
+++ b/R/one2one_freq.R
@@ -127,7 +127,7 @@ one2one_freq <- function(data,
         metric = "Cadence_of_1_on_1_meetings_with_manager",
         hrvar = hrvar,
         mingroup = mingroup,
-        cut = c(1, 1.5, 3, 6),
+        cut = c(0, 1.5, 3, 6),
         unit = "Weeks"
       )
 
@@ -143,7 +143,7 @@ one2one_freq <- function(data,
         metric = "Cadence_of_1_on_1_meetings_with_manager",
         hrvar = hrvar,
         mingroup = mingroup,
-        cut = c(1, 1.5, 3, 6),
+        cut = c(0, 1.5, 3, 6),
         unit = "Weeks",
         return = "table"
       )

--- a/R/one2one_freq.R
+++ b/R/one2one_freq.R
@@ -119,33 +119,53 @@ one2one_freq <- function(data,
 
   } else if(mode == "dist" & return == "plot"){
 
-    expanded_data$Cadence_of_1_on_1_meetings_with_manager[!is.finite(expanded_data$Cadence_of_1_on_1_meetings_with_manager)] <-
-      99
-
-    expanded_data %>%
-      create_dist(
-        metric = "Cadence_of_1_on_1_meetings_with_manager",
-        hrvar = hrvar,
-        mingroup = mingroup,
-        cut = c(0, 1.5, 3, 6),
-        unit = "Weeks"
+    plot_data <-
+      expanded_data %>%
+      mutate(
+        across(
+          .cols = Cadence_of_1_on_1_meetings_with_manager,
+          .fns = ~ifelse(!is.finite(.), 99, .)
+        )
       )
 
-
+    create_dist(
+      plot_data,
+      metric = "Cadence_of_1_on_1_meetings_with_manager",
+      hrvar = hrvar,
+      mingroup = mingroup,
+      cut = c(1, 1.5, 3, 6),
+      dist_colours = c("#facebc",
+                       "#fcf0eb",
+                       "#b4d5dd",
+                       "#bfe5ee",
+                       "grey90"),
+      unit = "Weeks"
+      )
 
   } else if(mode == "dist" & return == "table"){
 
-    expanded_data$Cadence_of_1_on_1_meetings_with_manager[!is.finite(expanded_data$Cadence_of_1_on_1_meetings_with_manager)] <-
-      99
+    plot_data <-
+      expanded_data %>%
+      mutate(
+        across(
+          .cols = Cadence_of_1_on_1_meetings_with_manager,
+          .fns = ~ifelse(!is.finite(.), 99, .)
+        )
+      )
 
-    expanded_data %>%
-      create_dist(
-        metric = "Cadence_of_1_on_1_meetings_with_manager",
-        hrvar = hrvar,
-        mingroup = mingroup,
-        cut = c(0, 1.5, 3, 6),
-        unit = "Weeks",
-        return = "table"
+    create_dist(
+      plot_data,
+      metric = "Cadence_of_1_on_1_meetings_with_manager",
+      hrvar = hrvar,
+      mingroup = mingroup,
+      cut = c(1, 1.5, 3, 6),
+      dist_colours = c("#facebc",
+                       "#fcf0eb",
+                       "#b4d5dd",
+                       "#bfe5ee",
+                       "grey90"),
+      unit = "Weeks",
+      return = "table"
       )
 
   }


### PR DESCRIPTION
# Summary
This branch fixes an issue with `one2one_freq()`.

# Changes
The changes made in this PR are:
1. Fixes an issue with `one2one_freq()`

The solution appears to be that in `create_dist()`, which is called from `one2one_freq()`, previously defaulted to the `dist_colours` argument having a length of 4. In fact,  5 is needed, which was causing the previous error.

# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

