### PR TITLE
Feature: improve return outputs of working patterns functions

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -4,7 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 .onAttach <- function(libname, pkgname) {
-  message <- c("\n Thank you for using v1.4.3 of the {wpa} R package!",
+  message <- c("\n Thank you for using the {wpa} R package!",
                "\n \n Our analysts have taken every care to ensure that this package runs smoothly and bug-free.",
                "\n \n However, if you do happen to encounter any, please report any issues at",
                "\n https://github.com/microsoft/wpa/issues/",

--- a/R/workpatterns_classify.R
+++ b/R/workpatterns_classify.R
@@ -24,20 +24,6 @@
 #'
 #'   This method classifies each **person-week** into one of the seven
 #'   archetypes:
-#'   - 0 < 3 hours on
-#'   - 1 Standard with breaks workday
-#'   - 2 Standard continuous workday
-#'   - 3 Standard flexible workday
-#'   - 4 Long flexible workday
-#'   - 5 Long continuous workday
-#'   - 6 Always on (13h+)
-#'
-#'   This is the recommended method over `pav` for several reasons:
-#'   1. `bw` ignores _volume effects_, where activity volume can still bias the
-#'   results towards the 'standard working hours'.
-#'   2. It captures the intuition that each individual can have 'light' and
-#'   'heavy' weeks with respect to workload.
-#'
 #'   - **0 < 3 hours on**: fewer than 3 hours of active hours
 #'   - **1 Standard with breaks workday**: active for fewer than _expected
 #'   hours_, with no activity outside working hours
@@ -52,19 +38,16 @@
 #'   - **6 Always on (13h+)**: number of active hours greater than or equal to
 #'   13
 #'
+#'   This is the recommended method over `pav` for several reasons:
+#'   1. `bw` ignores _volume effects_, where activity volume can still bias the
+#'   results towards the 'standard working hours'.
+#'   2. It captures the intuition that each individual can have 'light' and
+#'   'heavy' weeks with respect to workload.
+#'
 #' @section Person Average method:
 #'
 #'   This method classifies each **person** (based on unique `PersonId`) into
 #'   one of the six archetypes:
-#'   - Absent
-#'   - Extended Hours - Morning
-#'   - Extended Hours - Evening
-#'   - Overnight workers
-#'   - Standard Hours
-#'   - Always On
-#'
-#' The Person Average archetypes are defined as follows:
-#'
 #' - **Absent**: Fewer than 10 signals over the week.
 #'
 #' - **Extended Hours - Morning:** 15%+ of collaboration before start hours and

--- a/R/workpatterns_classify.R
+++ b/R/workpatterns_classify.R
@@ -38,6 +38,20 @@
 #'   2. It captures the intuition that each individual can have 'light' and
 #'   'heavy' weeks with respect to workload.
 #'
+#'   - **0 < 3 hours on**: fewer than 3 hours of active hours
+#'   - **1 Standard with breaks workday**: active for fewer than _expected
+#'   hours_, with no activity outside working hours
+#'   - **2 Standard continuous workday**: number of active hours equal _expected
+#'   hours_, with no activity outside working hours
+#'   - **3 Standard flexible workday**: number of active hours are less than or
+#'   equal to _expected hours_, with some activity outside working hours
+#'   - **4 Long flexible workday**: number of active hours exceed _expected
+#'   hours_, with breaks occurring throughout
+#'   - **5 Long continuous workday**: number of active hours exceed _expected
+#'   hours_, with activity happening in a continuous block (no breaks)
+#'   - **6 Always on (13h+)**: number of active hours greater than or equal to
+#'   13
+#'
 #' @section Person Average method:
 #'
 #'   This method classifies each **person** (based on unique `PersonId`) into
@@ -48,6 +62,28 @@
 #'   - Overnight workers
 #'   - Standard Hours
 #'   - Always On
+#'
+#' The Person Average archetypes are defined as follows:
+#'
+#' - **Absent**: Fewer than 10 signals over the week.
+#'
+#' - **Extended Hours - Morning:** 15%+ of collaboration before start hours and
+#' less than 70% within standard hours, and less than 15% of collaboration after
+#' end hours
+#'
+#' - **Extended Hours - Evening**: Less than 15% of collaboration before start
+#' hours and less than 70% within standard hours, and 15%+ of collaboration
+#' after end hours
+#'
+#' - **Overnight workers**: less than 30% of collaboration happens within
+#' standard hours
+#'
+#' - **Standard Hours**: over 70% of collaboration within standard hours
+#'
+#' - **Always On**: over 15% of collaboration happens before starting hour and
+#' end hour (both conditions must satisfy) and less than 70% of collaboration
+#' within standard hours
+#'
 #'
 #' @section Flexibility Index: The Working Patterns archetypes as calculated
 #'   using the binary-week method shares many similarities with the Flexibility

--- a/R/workpatterns_classify.R
+++ b/R/workpatterns_classify.R
@@ -70,9 +70,11 @@
 #'
 #' @section Flexibility Index: The Working Patterns archetypes as calculated
 #'   using the binary-week method shares many similarities with the Flexibility
-#'   Index (see `flex_index()`): - Both are computed directly from the Hourly
-#'   Collaboration Flexible Query. - Both apply the same binary conversion of
-#'   activity on the signals from the Hourly Collaboration Flexible Query.
+#'   Index (see `flex_index()`):
+#'
+#'   - Both are computed directly from the Hourly Collaboration Flexible Query.
+#'   - Both apply the same binary conversion of activity on the signals from the
+#'   Hourly Collaboration Flexible Query.
 #'
 #'
 #' @param data A data frame containing data from the Hourly Collaboration query.

--- a/man/workpatterns_classify.Rd
+++ b/man/workpatterns_classify.Rd
@@ -101,23 +101,6 @@ implementations.
 This method classifies each \strong{person-week} into one of the seven
 archetypes:
 \itemize{
-\item 0 < 3 hours on
-\item 1 Standard with breaks workday
-\item 2 Standard continuous workday
-\item 3 Standard flexible workday
-\item 4 Long flexible workday
-\item 5 Long continuous workday
-\item 6 Always on (13h+)
-}
-
-This is the recommended method over \code{pav} for several reasons:
-\enumerate{
-\item \code{bw} ignores \emph{volume effects}, where activity volume can still bias the
-results towards the 'standard working hours'.
-\item It captures the intuition that each individual can have 'light' and
-'heavy' weeks with respect to workload.
-}
-\itemize{
 \item \strong{0 < 3 hours on}: fewer than 3 hours of active hours
 \item \strong{1 Standard with breaks workday}: active for fewer than \emph{expected
 hours}, with no activity outside working hours
@@ -132,6 +115,14 @@ hours}, with activity happening in a continuous block (no breaks)
 \item \strong{6 Always on (13h+)}: number of active hours greater than or equal to
 13
 }
+
+This is the recommended method over \code{pav} for several reasons:
+\enumerate{
+\item \code{bw} ignores \emph{volume effects}, where activity volume can still bias the
+results towards the 'standard working hours'.
+\item It captures the intuition that each individual can have 'light' and
+'heavy' weeks with respect to workload.
+}
 }
 
 \section{Person Average method}{
@@ -139,16 +130,6 @@ hours}, with activity happening in a continuous block (no breaks)
 
 This method classifies each \strong{person} (based on unique \code{PersonId}) into
 one of the six archetypes:
-\itemize{
-\item Absent
-\item Extended Hours - Morning
-\item Extended Hours - Evening
-\item Overnight workers
-\item Standard Hours
-\item Always On
-}
-
-The Person Average archetypes are defined as follows:
 \itemize{
 \item \strong{Absent}: Fewer than 10 signals over the week.
 \item \strong{Extended Hours - Morning:} 15\%+ of collaboration before start hours and

--- a/man/workpatterns_classify.Rd
+++ b/man/workpatterns_classify.Rd
@@ -117,6 +117,21 @@ results towards the 'standard working hours'.
 \item It captures the intuition that each individual can have 'light' and
 'heavy' weeks with respect to workload.
 }
+\itemize{
+\item \strong{0 < 3 hours on}: fewer than 3 hours of active hours
+\item \strong{1 Standard with breaks workday}: active for fewer than \emph{expected
+hours}, with no activity outside working hours
+\item \strong{2 Standard continuous workday}: number of active hours equal \emph{expected
+hours}, with no activity outside working hours
+\item \strong{3 Standard flexible workday}: number of active hours are less than or
+equal to \emph{expected hours}, with some activity outside working hours
+\item \strong{4 Long flexible workday}: number of active hours exceed \emph{expected
+hours}, with breaks occurring throughout
+\item \strong{5 Long continuous workday}: number of active hours exceed \emph{expected
+hours}, with activity happening in a continuous block (no breaks)
+\item \strong{6 Always on (13h+)}: number of active hours greater than or equal to
+13
+}
 }
 
 \section{Person Average method}{
@@ -131,6 +146,23 @@ one of the six archetypes:
 \item Overnight workers
 \item Standard Hours
 \item Always On
+}
+
+The Person Average archetypes are defined as follows:
+\itemize{
+\item \strong{Absent}: Fewer than 10 signals over the week.
+\item \strong{Extended Hours - Morning:} 15\%+ of collaboration before start hours and
+less than 70\% within standard hours, and less than 15\% of collaboration after
+end hours
+\item \strong{Extended Hours - Evening}: Less than 15\% of collaboration before start
+hours and less than 70\% within standard hours, and 15\%+ of collaboration
+after end hours
+\item \strong{Overnight workers}: less than 30\% of collaboration happens within
+standard hours
+\item \strong{Standard Hours}: over 70\% of collaboration within standard hours
+\item \strong{Always On}: over 15\% of collaboration happens before starting hour and
+end hour (both conditions must satisfy) and less than 70\% of collaboration
+within standard hours
 }
 }
 

--- a/man/workpatterns_classify.Rd
+++ b/man/workpatterns_classify.Rd
@@ -150,9 +150,12 @@ within standard hours
 \section{Flexibility Index}{
  The Working Patterns archetypes as calculated
 using the binary-week method shares many similarities with the Flexibility
-Index (see \code{flex_index()}): - Both are computed directly from the Hourly
-Collaboration Flexible Query. - Both apply the same binary conversion of
-activity on the signals from the Hourly Collaboration Flexible Query.
+Index (see \code{flex_index()}):
+\itemize{
+\item Both are computed directly from the Hourly Collaboration Flexible Query.
+\item Both apply the same binary conversion of activity on the signals from the
+Hourly Collaboration Flexible Query.
+}
 }
 
 \examples{


### PR DESCRIPTION
# Summary
This branch makes improvement to some outputs of working patterns functions. 

# Changes
The changes made in this PR are:
1. Made possible for the `"data"` return option for `workpatterns_classify_bw()` to return HR attributes. (#129)
1. Removed the confusing `Signals.Total.x` and `Signals.Total.y` which is resulted from a duplicate column when performing a joining between datasets for `workpatterns_classify_bw()`. 
1. Added documentation of definitions for working patterns. (#124)
1. Removed package version number from start-up message to avoid inconsistency. 

# Checks
- [ ] All R CMD checks pass 
- [ ] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.

# Notes
This fixes #124 and #129.

