### PR TITLE
Feature: implement Doc Search

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,11 @@
+url: https://microsoft.github.io/wpa/
+
 template:
   params:
     bootswatch: cosmo
+    docsearch: 
+      api_key: f45eacc22edb0c386f1f5b9bb89f76be
+      index_name: wpa
   path: "inst/pkgdown"
 
 navbar:


### PR DESCRIPTION
# Summary
This pull request updates `_pkgdown.yml` to implement the Doc Search function. Instructions as per <https://pkgdown.r-lib.org/articles/search.html>.

This branch is merged with `cran-mirror` rather than `main` to immediately deploy the search function (`main` is not deployed until the latest version of the package is submitted and accepted to CRAN). 

