### PR TITLE
Feature: add meetings and unscheduled call signals for `flex_index()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wpa
 Type: Package
 Title: Tools for Analysing and Visualising Workplace Analytics Data
-Version: 1.6.1
+Version: 1.6.1.9000
 Authors@R: c(
     person(given = "Martin", family = "Chan", role = c("aut", "cre"), email = "martin.chan@microsoft.com"),
     person(given = "Carlos", family = "Morales", role = "aut", email = "carlos.morales@microsoft.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# wpa (development version)
+
 # wpa 1.6.1
 - Fixed several minor bugs reported on GitHub (#177, #178, #180, #181)
 - Refurbished `meeting_tm_report()` (#173)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # wpa (development version)
+- Added new signal options for `flex_index()` (#183)
+- Minor bugs fixed (#181)
+
 
 # wpa 1.6.1
 - Fixed several minor bugs reported on GitHub (#177, #178, #180, #181)

--- a/R/flex_index.R
+++ b/R/flex_index.R
@@ -67,8 +67,12 @@
 #'   Defaults to NULL. This only affects the function when "table" is returned.
 #'
 #' @param signals Character vector to specify which collaboration metrics to
-#'   use: You may use "email" for emails only, "IM" for Teams messages only, or
-#'   a combination of the two `c("email", "IM")` (default).
+#'   use:
+#'   - a combination of signals, such as `c("email", "IM")` (default)
+#'   - `"email"` for emails only
+#'   - `"IM"` for Teams messages only
+#'   - `"unscheduled_calls"` for Unscheduled Calls only
+#'   - `"meetings"` for Meetings only
 #'
 #' @param active_threshold A numeric value specifying the minimum number of
 #'   signals to be greater than in order to qualify as _active_. Defaults to 0.
@@ -167,52 +171,13 @@ flex_index <- function(data,
     data.table::as.data.table() %>%
     data.table::copy()
 
-  ## Select input variable names
-  if("email" %in% signals & "IM" %in% signals){
+  ## Text replacement only for allowed values
+  if(any(signals %in% c("email", "IM", "unscheduled_calls", "meetings"))){
 
-    ## Create 24 summed `Signals_sent` columns
-    signal_cols <-
-      purrr::map(0:23, ~wpa::combine_signals(data2, hr = .)) %>%
-      dplyr::bind_cols()
-
-    ## Use names for matching
-    input_var <- names(signal_cols)
-
-    ## Signals sent by Person and date
-    signals_df <-
-      data2 %>%
-      .[, c("PersonId", "Date")] %>%
-      cbind(signal_cols)
-
-    ## Signal label
-    sig_label <- "Signals_sent"
-
-  } else if(signals == "IM"){
-
-    match_index <- grepl(pattern = "^IMs_sent", x = names(data2))
-    input_var <- names(data2)[match_index]
-    input_var2 <- c("PersonId", "Date", input_var)
-
-    ## signals sent by Person and date
-    signals_df <-
-      data2 %>%
-      .[, ..input_var2]
-
-    sig_label <- "IMs_sent"
-
-
-  } else if(signals == "email"){
-
-    match_index <- grepl(pattern = "^Emails_sent", x = names(data2))
-    input_var <- names(data2)[match_index]
-    input_var2 <- c("PersonId", "Date", input_var)
-
-    ## signals sent by Person and date
-    signals_df <-
-      data2 %>%
-      .[, ..input_var2]
-
-    sig_label <- "Emails_sent"
+    signal_set <- gsub(pattern = "email", replacement = "Emails_sent", x = signals) # case-sensitive
+    signal_set <- gsub(pattern = "IM", replacement = "IMs_sent", x = signal_set)
+    signal_set <- gsub(pattern = "unscheduled_calls", replacement = "Unscheduled_calls", x = signal_set)
+    signal_set <- gsub(pattern = "meetings", replacement = "Meetings", x = signal_set)
 
   } else {
 
@@ -220,6 +185,21 @@ flex_index <- function(data,
 
   }
 
+  ## Create 24 summed `Signals_sent` columns
+  signal_cols <- purrr::map(0:23, ~combine_signals(data, hr = ., signals = signal_set))
+  signal_cols <- bind_cols(signal_cols)
+
+  ## Use names for matching
+  input_var <- names(signal_cols)
+
+  ## Signals sent by Person and Date
+  signals_df <-
+    data2 %>%
+    .[, c("PersonId", "Date")] %>%
+    cbind(signal_cols)
+
+  ## Signal label
+  sig_label <- ifelse(length(signal_set) > 1, "Signals_sent", signal_set)
 
   ## Create binary variable 0 or 1
   num_cols <- names(which(sapply(signals_df, is.numeric))) # Get numeric columns

--- a/R/plot_flex_index.R
+++ b/R/plot_flex_index.R
@@ -126,7 +126,7 @@ plot_flex_index <- function(data,
       ggplot2::ggplot(ggplot2::aes(x = Hours, y = patternRank, fill = Freq)) +
       ggplot2::geom_tile(height=.5) +
       ggplot2::ylab("Work Patterns") +
-      ggplot2::scale_fill_gradient2(low = "white", high = "red") +
+      ggplot2::scale_fill_gradient2(low = "white", high = "#1d627e") +
       ggplot2::scale_y_reverse(breaks=seq(1,10)) +
       wpa::theme_wpa_basic() +
       ggplot2::theme(legend.position = "none") +
@@ -146,14 +146,14 @@ plot_flex_index <- function(data,
                         ymin = 0.5,
                         ymax = 10 + 0.5,
                         alpha = .1,
-                        fill = "red") +
+                        fill = "gray50") +
       ggplot2::annotate("rect",
                         xmin = end_hour + 0.5,
                         xmax = 24.5,
                         ymin = 0.5,
                         ymax = 10 + 0.5,
                         alpha = .1,
-                        fill = "red") +
+                        fill = "gray50") +
       ggplot2::labs(title = "Work Patterns and Flexibility Index",
                     subtitle = paste0(plot_title,
                                       "\n",

--- a/R/workpatterns_classify_bw.R
+++ b/R/workpatterns_classify_bw.R
@@ -122,8 +122,7 @@ workpatterns_classify_bw <- function(data,
   ## e.g. if `end_hour` value is 17, then the reference slot should be 16
   d <- (end_hour - 1) - start_hour
 
-  # Text replacement only for allowed values
-
+  ## Text replacement only for allowed values
   if(any(signals %in% c("email", "IM", "unscheduled_calls", "meetings"))){
 
     signal_set <- gsub(pattern = "email", replacement = "Emails_sent", x = signals) # case-sensitive

--- a/man/flex_index.Rd
+++ b/man/flex_index.Rd
@@ -22,8 +22,14 @@ flex_index(
 Defaults to NULL. This only affects the function when "table" is returned.}
 
 \item{signals}{Character vector to specify which collaboration metrics to
-use: You may use "email" for emails only, "IM" for Teams messages only, or
-a combination of the two \code{c("email", "IM")} (default).}
+use:
+\itemize{
+\item a combination of signals, such as \code{c("email", "IM")} (default)
+\item \code{"email"} for emails only
+\item \code{"IM"} for Teams messages only
+\item \code{"unscheduled_calls"} for Unscheduled Calls only
+\item \code{"meetings"} for Meetings only
+}}
 
 \item{active_threshold}{A numeric value specifying the minimum number of
 signals to be greater than in order to qualify as \emph{active}. Defaults to 0.}


### PR DESCRIPTION
# Summary
This branch add meetings and unscheduled call signals for `flex_index()`, as per #183. Some visual improvements are also made to top work pattern plots. 

# Changes
The changes made in this PR are:
1. Add meetings and unscheduled call signals for `flex_index()`.
2. Bring colour formatting in the work patterns plots in `flex_index()` in line with `workpatterns_classify()`. The underlying code is edited at `plot_flex_index()` (see `workpatterns_classify_bw()`)
3. Increment to development version `1.6.1.9000`


# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.
- [x] `NEWS.md` has been updated.

# Notes
This fixes #183.
