### PR TITLE
Feature: make use of `Call_hours` dynamic in `validation_report()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # wpa (development version)
 - Added new signal options for `flex_index()` (#183)
+- Minor feature improvements (#186)
 - Minor bugs fixed (#181)
 
 

--- a/R/validation_report.R
+++ b/R/validation_report.R
@@ -24,6 +24,10 @@
 #' Person query to the `data` argument, please also use `standardise_pq()` to
 #' make the variable names consistent with a Standard Person Query.
 #'
+#' Since `v1.6.2`, the variable `Call_hours` is no longer a pre-requisite to run
+#' this report. A note is returned in-line instead of an error if the variable
+#' is not available.
+#'
 #' @section Checking functions within `validation_report()`:
 #'   - `check_query()`
 #'   - `flag_ch_ratio()`

--- a/R/validation_report.R
+++ b/R/validation_report.R
@@ -127,6 +127,43 @@ validation_report <- function(data,
     trackhr_obj2 <- ""
   }
 
+  ## Dynamic: create mock `Call_hours` variable
+  callthres_p <- NULL
+  callthres <- NULL
+
+
+  if("Call_hours" %in% names(data)){
+    callthres_p <- paste(
+      ">",
+      data %>%
+        flag_extreme(
+          metric = "Call_hours",
+          threshold = 40,
+          person = TRUE,
+          return = "text"
+        )
+    )
+
+    callthres <-
+      paste(
+        ">",
+        data %>% flag_extreme(
+          metric = "Call_hours",
+          threshold = 40,
+          person = FALSE,
+          return = "text"
+        )
+      )
+
+  } else {
+
+    callthres_p <-
+      "> [Note] Checks for `Call_hours is not available due to missing variable."
+    callthres <- callthres_p
+
+  }
+
+
   ## Outputs as accessed here
   ## Can be data frames, plot objects, or text
   output_list <-
@@ -194,8 +231,8 @@ validation_report <- function(data,
          paste(">",data %>% flag_extreme(metric = "Meeting_hours", threshold = 80, person = TRUE, return = "text")),
          paste(">",data %>% flag_extreme(metric = "Meeting_hours", threshold = 80, person = FALSE, return = "text")),
 
-         paste(">",data %>% flag_extreme(metric = "Call_hours", threshold = 40, person = TRUE, return = "text")),
-         paste(">",data %>% flag_extreme(metric = "Call_hours", threshold = 40, person = FALSE, return = "text")),
+         callthres_p,
+         callthres,
 
          paste(">",data %>% flag_extreme(metric = "Instant_Message_hours", threshold = 40, person = TRUE, return = "text")),
          paste(">",data %>% flag_extreme(metric = "Instant_Message_hours", threshold = 40, person = FALSE, return = "text")),

--- a/man/validation_report.Rd
+++ b/man/validation_report.Rd
@@ -55,6 +55,10 @@ standardize format and prepare the data as input for this report.
 If you are passing a Ways of Working Assessment query instead of a Standard
 Person query to the \code{data} argument, please also use \code{standardise_pq()} to
 make the variable names consistent with a Standard Person Query.
+
+Since \code{v1.6.2}, the variable \code{Call_hours} is no longer a pre-requisite to run
+this report. A note is returned in-line instead of an error if the variable
+is not available.
 }
 \section{Checking functions within \code{validation_report()}}{
 


### PR DESCRIPTION
# Summary
Some person flexible queries no longer provide `Call_hours` by default. This branch implements a feature change that makes the use of the variable dynamic and prevents it from returning an error if missing.


# Changes
The changes made in this PR are:
1. Make the use of `Call_hours` variable dynamic in `validation_report()`
2. Update documentation in `validation_report()` and `NEWS.md` accordingly. 
3. Prepare release of `v1.6.2`.


# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.
- [x] `NEWS.md` has been updated.
