### PR TITLE
Fix: only call `replace_na(., 0)` on numeric columns

### DIFF
--- a/R/workpatterns_area.R
+++ b/R/workpatterns_area.R
@@ -158,7 +158,7 @@ workpatterns_area <- function(data,
   ptn_data_norm <-
     ptn_data_norm %>%
     select(PersonId, group, all_of(input_var)) %>%
-    mutate_all(~tidyr::replace_na(., 0)) # Replace NAs with 0s
+    mutate(across(where(is.numeric), ~tidyr::replace_na(., 0))) # Replace NAs with 0s
 
   # Percentage vs Absolutes
   if(values == "percent"){

--- a/R/workpatterns_classify_pav.R
+++ b/R/workpatterns_classify_pav.R
@@ -104,7 +104,7 @@ workpatterns_classify_pav <- function(data,
     mutate_at(vars(all_of(input_var)), ~./Signals_Total) %>%
     #filter(Signals_Total > 0) %>%
     select(all_of(input_var)) %>%
-    mutate_all(~tidyr::replace_na(., 0)) # Replace NAs with 0s
+    mutate(across(where(is.numeric), ~tidyr::replace_na(., 0))) # Replace NAs with 0s
 
 
   ## Normalised pattern data

--- a/R/workpatterns_hclust.R
+++ b/R/workpatterns_hclust.R
@@ -131,7 +131,7 @@ workpatterns_hclust <- function(data,
     mutate_at(vars(input_var), ~./Signals_Total) %>%
     filter(Signals_Total > 0) %>%
     select(PersonId, all_of(input_var)) %>%
-    mutate_all(~tidyr::replace_na(., 0)) # Replace NAs with 0s
+    mutate(across(where(is.numeric), ~tidyr::replace_na(., 0))) # Replace NAs with 0s
 
   ## Distance matrix
   dist_m <-


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize the vctrs package, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the above mentioned PR and running:

``` r
library(wpa)

# Create a sample small dataset
orgs <- c("Customer Service", "Financial Planning", "Biz Dev")
em_data <- em_data[em_data$Organization %in% orgs, ]

# Return visualization of percentage distribution
workpatterns_area(em_data, return = "plot", values = "percent")
#> Error: Problem with `mutate()` column `PersonId`.
#> ℹ `PersonId = (structure(function (..., .x = ..1, .y = ..2, . = ..1) ...`.
#> x Can't convert `replace` <double> to match type of `data` <character>.
```

The problem boils down to the fact that you are calling `mutate_all(df, ~replace_na(., 0))` on a `df` that has a mixture of character and numeric columns. Notably, `PersonId` and `group` are character columns, and you can no longer use a numeric `0` as a replacement value for these.

It seems like you probably just wanted to replace NAs in numeric columns, so this PR changes to a `mutate()` call that targets only numeric columns.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!