### PR TITLE
Ungroup before completing

### DIFF
--- a/R/workpatterns_classify_bw.R
+++ b/R/workpatterns_classify_bw.R
@@ -299,6 +299,7 @@ workpatterns_classify_bw <- function(data,
       dplyr::group_by(Date, Personas) %>%
       dplyr::summarise(n = dplyr::n_distinct(PersonId)) %>%
       dplyr::mutate(per = n / sum(n)) %>%
+      dplyr::ungroup() %>%
       tidyr::complete(Date, Personas, fill = list(0)) %>%
       mutate(per = tidyr::replace_na(per, 0)) %>%
       ggplot(aes(x=Date, y=per, fill=Personas)) +


### PR DESCRIPTION
We are planning on releasing tidyr 1.2.0 towards the end of this month.

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run this code:

``` r
library(wpa)

em_data %>% 
  workpatterns_classify(method = "bw", return = "plot-area")
#> Error: Problem with `summarise()` input `..1`.
#> ℹ `..1 = complete(data = dplyr::cur_data(), ..., fill = fill, explicit = explicit)`.
#> x object 'Date' not found
#> ℹ The error occurred in group 1: Date = 2020-01-05.
```

The problem comes down to the fact that you are trying to `complete()` on a grouping variable, `Date`. In the development version, `complete()` has been fixed to actually work correctly with grouped data frames in all cases (see https://github.com/tidyverse/tidyr/issues/396 and https://github.com/tidyverse/tidyr/issues/966). One of the restrictions of this is that you can no longer complete on a grouping column. This didn't make much sense anyways because with grouped data frames `complete()` was supposed to be working "within" each group.

It seems like this was accidental, and you really just needed a call to `ungroup()`, so that is what this PR adds.

This should work on both the current and development version of tidyr, so you should be able to go ahead and do a patch release. We would greatly appreciate if you could do this so we can release tidyr! Thank you!