### PR TITLE
Bugfix: make Louvain implementation in `network_p2p()` deterministic (#221)

### DIFF
--- a/R/network_p2p.R
+++ b/R/network_p2p.R
@@ -60,8 +60,10 @@
 #'   of the edges (only for 'ggraph' mode). Defaults to 1.
 #' @param res Resolution parameter to be passed to `leiden::leiden()`. Defaults
 #'   to 0.5.
-#' @param seed Seed for the random number generator passed to `leiden::leiden()`
-#'   to ensure consistency. Only applicable when `display` is set to `"leiden"`.
+#' @param seed Seed for the random number generator passed to either
+#'   `set.seed()` when the Louvain algorithm is used, or `leiden::leiden()` when
+#'   the Leiden algorithm is used, to ensure consistency. Only applicable when
+#'   `display` is set to `"louvain"` or `"leiden"`.
 #' @param algorithm String to specify the node placement algorithm to be used.
 #'   Defaults to `"mds"` for the deterministic multi-dimensional scaling of
 #'   nodes. See
@@ -241,24 +243,26 @@ network_p2p <- function(data,
 
     } else if(display == "louvain"){
 
-    ## Convert to undirected
-    g_ud <- igraph::as.undirected(g_raw)
+      set.seed(seed = seed)
 
-    ## Return a numeric vector of partitions / clusters / modules
-    ## Set a low resolution parameter to have fewer groups
-    ## weights = NULL means that if the graph as a `weight` edge attribute, this
-    ## will be used by default.
-    lc <- igraph::cluster_louvain(g_ud, weights = NULL)
+      ## Convert to undirected
+      g_ud <- igraph::as.undirected(g_raw)
 
-    ## Add cluster
-    g <-
-      g_ud %>%
-      # Add louvain partitions to graph object
-      igraph::set_vertex_attr("cluster", value = as.character(igraph::membership(lc))) %>% # Return membership - diff from Leiden
-      igraph::simplify()
+      ## Return a numeric vector of partitions / clusters / modules
+      ## Set a low resolution parameter to have fewer groups
+      ## weights = NULL means that if the graph as a `weight` edge attribute, this
+      ## will be used by default.
+      lc <- igraph::cluster_louvain(g_ud, weights = NULL)
 
-    ## Name of vertex attribute
-    v_attr <- "cluster"
+      ## Add cluster
+      g <-
+        g_ud %>%
+        # Add louvain partitions to graph object
+        igraph::set_vertex_attr("cluster", value = as.character(igraph::membership(lc))) %>% # Return membership - diff from Leiden
+        igraph::simplify()
+
+      ## Name of vertex attribute
+      v_attr <- "cluster"
 
   } else if(display == "leiden"){
 

--- a/man/network_leiden.Rd
+++ b/man/network_leiden.Rd
@@ -44,8 +44,10 @@ of the nodes. Defaults to 0.7.}
 \item{res}{Resolution parameter to be passed to \code{leiden::leiden()}. Defaults
 to 0.5.}
 
-\item{seed}{Seed for the random number generator passed to \code{leiden::leiden()}
-to ensure consistency. Only applicable when \code{display} is set to \code{"leiden"}.}
+\item{seed}{Seed for the random number generator passed to either
+\code{set.seed()} when the Louvain algorithm is used, or \code{leiden::leiden()} when
+the Leiden algorithm is used, to ensure consistency. Only applicable when
+\code{display} is set to \code{"louvain"} or \code{"leiden"}.}
 
 \item{desc_hrvar}{Character vector of length 3 containing the HR attributes
 to use when returning the \code{"describe"} output. See \code{network_describe()}.}

--- a/man/network_p2p.Rd
+++ b/man/network_p2p.Rd
@@ -86,8 +86,10 @@ of the edges (only for 'ggraph' mode). Defaults to 1.}
 \item{res}{Resolution parameter to be passed to \code{leiden::leiden()}. Defaults
 to 0.5.}
 
-\item{seed}{Seed for the random number generator passed to \code{leiden::leiden()}
-to ensure consistency. Only applicable when \code{display} is set to \code{"leiden"}.}
+\item{seed}{Seed for the random number generator passed to either
+\code{set.seed()} when the Louvain algorithm is used, or \code{leiden::leiden()} when
+the Leiden algorithm is used, to ensure consistency. Only applicable when
+\code{display} is set to \code{"louvain"} or \code{"leiden"}.}
 
 \item{algorithm}{String to specify the node placement algorithm to be used.
 Defaults to \code{"mds"} for the deterministic multi-dimensional scaling of


### PR DESCRIPTION
# Summary
This branch fixes a bug reported in #221 where the Louvain implementation in `network_p2p()` cannot be made deterministic. 

# Changes
The changes made in this PR are:
1. Expands the ability to set seed within the function environment with the `seed` argument in `network_p2p()` to when `display = "louvain"` (previously only affects `display = "leiden"`). 
2. Update relevant documentation. 

# Validation
This fix is confirmed to be working with:
```R
library(wpa)

p2p_data <- p2p_data_sim()

a <- 
  p2p_data %>%
  network_p2p(
    display = "louvain",
    return = "table",
    seed = 100
  )

b <- 
  p2p_data %>%
  network_p2p(
    display = "louvain",
    return = "table",
    seed = 100
  )

nrow(a) == nrow(b)

all(a$cluster == b$cluster)
```

# Checks
- [x] All R CMD checks pass 
- [x] `roxygen2::roxygenise()` has been run prior to merging to ensure that `.Rd` and `NAMESPACE` files are up to date.
- [x] `NEWS.md` has been updated.

# Notes
This fixes #221.

