### PR TITLE
Eagerly convert from and to data.table and patch `v1.8.1`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2-branch
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 1.8.0
-Date: 2022-07-05 14:56:34 UTC
-SHA: da3ceafbd54598a196fe0c3c1b29f58f1adc728d
+Version: 1.8.1
+Date: 2023-01-27 11:02:41 UTC
+SHA: da6fe2da817d04f06e90017f92f82cb788d093df

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: wpa
 Type: Package
 Title: Tools for Analysing and Visualising Viva Insights Data
-Version: 1.8.0
+Version: 1.8.1
 Authors@R: c(
     person(given = "Martin", family = "Chan", role = c("aut", "cre"), email = "martin.chan@microsoft.com"),
     person(given = "Carlos", family = "Morales", role = "aut", email = "carlos.morales@microsoft.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# wpa 1.8.1
+
 # wpa 1.8.0
 
 - Updated and improved output and algorithm for `workpatterns_classify()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # wpa 1.8.1
 
+- fixed issue due to a 'tidyr' update (see #233).
+
 # wpa 1.8.0
 
 - Updated and improved output and algorithm for `workpatterns_classify()`

--- a/R/workpatterns_classify_bw.R
+++ b/R/workpatterns_classify_bw.R
@@ -234,7 +234,8 @@ workpatterns_classify_bw <- function(data,
   WpA_classify <-
     WpA_classify[, c("PersonId", "Date", "Active_Hours", "HourType", "sent")] %>%
     .[, .(sent = sum(sent)), by = c("PersonId", "Date", "Active_Hours", "HourType")] %>%
-    tidyr::spread(HourType, sent)%>%
+    dplyr::as_tibble() %>%
+    tidyr::spread(HourType, sent) %>%
     left_join(WpA_classify %>%   ## Calculate first and last activity for day_span
                 filter(sent > 0)%>%
                 group_by(PersonId, Date)%>%
@@ -242,7 +243,8 @@ workpatterns_classify_bw <- function(data,
                           Last_signal = max(End)),
               by = c("PersonId","Date"))%>%
     mutate(Day_Span = Last_signal - First_signal,
-           Signals_Break_hours = Day_Span - Active_Hours)
+           Signals_Break_hours = Day_Span - Active_Hours) %>%
+  data.table::as.data.table()
 
 
   ## Working patterns classification ---------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # wpa <img src="https://raw.githubusercontent.com/microsoft/wpa/main/man/figures/logo2.png" align="right" width=15% />
 
   [![R build status](https://github.com/microsoft/wpa/workflows/R-CMD-check/badge.svg)](https://github.com/microsoft/wpa/actions/)
-  [![CodeFactor](https://www.codefactor.io/repository/github/microsoft/wpa/badge/)](https://www.codefactor.io/repository/github/microsoft/wpa/)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT/)
   [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
   [![CRAN status](https://www.r-pkg.org/badges/version/wpa)](https://CRAN.R-project.org/package=wpa/)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -7,6 +7,10 @@
 
 0 errors | 0 warnings | 0 note
 
+## Submission 1.8.1
+
+Patch to fix bug due to an update in 'tidyr' dependency
+
 ## Submission 1.8.0
 
 New functions and improving outputs of existing functions


### PR DESCRIPTION
Hi there,

We ran revdeps for the upcoming release of tidyr 1.3.0 and your package came up.

In dev tidyr we have reworked the way that data frame "restoration" is done in a number of the tidyr verbs to be simpler, more robust, and resolve a number of edge case issues. Unfortunately for wpa, this means that the data.table class is no longer preserved in a place where it was expected to be. I've fixed that with an explicit `as.data.table()` call.

We actually plan to release tidyr today. I'm not sure how wpa slipped through the cracks when we ran revdeps a few weeks ago. I'm sorry about that!

This patch is backwards compatible with CRAN tidyr.

Thanks!